### PR TITLE
Importer lets you use the data with the 'self.fields' field as a dict…

### DIFF
--- a/data_importer/tests/test_xls_importer.py
+++ b/data_importer/tests/test_xls_importer.py
@@ -11,7 +11,6 @@ LOCAL_DIR = os.path.dirname(__file__)
 
 
 class TestXLSImportMeta(TestCase):
-
     def setUp(self):
         class TestMeta(XLSImporter):
             fields = [
@@ -26,25 +25,38 @@ class TestXLSImportMeta(TestCase):
         self.xls_file = os.path.join(LOCAL_DIR, 'data/test.xls')
         self.importer = TestMeta(source=self.xls_file)
 
+        class TestMetaDict(XLSImporter):
+            fields = {
+                'business_place': 'A',
+                'doc_number': 'B',
+                'doc_data': 'C',
+            }
+
+            class Meta:
+                ignore_first_line = True
+
+        self.importer_dict = TestMetaDict(source=self.xls_file)
+
     def test_file_path(self):
         self.assertTrue(os.path.exists(self.xls_file))
 
     def test_values_is_valid(self):
         self.assertTrue(self.importer.is_valid())
+        self.assertTrue(self.importer_dict.is_valid())
 
     def test_count_rows(self):
         self.assertEqual(len(self.importer.cleaned_data), 9)
+        self.assertEqual(len(self.importer_dict.cleaned_data), 9)
 
     def test_cleaned_data_content(self):
         content = {
             'doc_number': 10000000,
             'business_place': u'SP',
             'doc_data': datetime.datetime(1982, 11, 1, 0, 0)
-            }
+        }
 
-        self.assertEquals(self.importer.cleaned_data[0], (1, content),
-                          self.importer.cleaned_data)
-
+        self.assertEquals(self.importer.cleaned_data[0], (1, content), self.importer.cleaned_data)
+        self.assertEquals(self.importer_dict.cleaned_data[0], (1, content), self.importer_dict.cleaned_data)
 
 
 class InvoiceXLS(models.Model):
@@ -57,7 +69,6 @@ class InvoiceXLS(models.Model):
 
 
 class TestModelXLSImporter(TestCase):
-
     def setUp(self):
         class TestMeta(XLSImporter):
             class Meta:
@@ -67,29 +78,42 @@ class TestModelXLSImporter(TestCase):
         self.xls_file = os.path.join(LOCAL_DIR, 'data/test.xls')
         self.importer = TestMeta(source=self.xls_file)
 
+        class TestMetaDict(XLSImporter):
+            class Meta:
+                ignore_first_line = True
+                model = InvoiceXLS
+
+        self.importer_dict = TestMetaDict(source=self.xls_file)
+
     def test_values_is_valid(self):
         self.assertTrue(self.importer.is_valid())
+        self.assertTrue(self.importer_dict.is_valid())
 
     def test_count_rows(self):
         self.assertEqual(len(self.importer.cleaned_data), 9)
+        self.assertEqual(len(self.importer_dict.cleaned_data), 9)
 
     def test_cleaned_data_content(self):
         content = {
             'doc_number': 10000000,
             'business_place': u'SP',
             'doc_data': datetime.datetime(1982, 11, 1, 0, 0)
-            }
+        }
 
-        self.assertEquals(self.importer.cleaned_data[0], (1, content),
-                          self.importer.cleaned_data)
+        self.assertEquals(self.importer.cleaned_data[0], (1, content), self.importer.cleaned_data)
+        self.assertEquals(self.importer_dict.cleaned_data[0], (1, content), self.importer_dict.cleaned_data)
 
     def test_save_data(self):
         for row, data in self.importer.cleaned_data:
             instace = InvoiceXLS(**data)
             self.assertTrue(instace.save())
+        for row, data in self.importer_dict.cleaned_data:
+            instace = InvoiceXLS(**data)
+            self.assertTrue(instace.save())
 
     def test_save_importer(self):
         self.assertTrue(self.importer.save())
+        self.assertTrue(self.importer_dict.save())
 
 
 class MercadoXLS(models.Model):
@@ -101,7 +125,6 @@ class MercadoXLS(models.Model):
 
 
 class TestPTBRXLSImporter(TestCase):
-
     def setUp(self):
         class TestMeta(XLSImporter):
             class Meta:
@@ -121,7 +144,7 @@ class TestPTBRXLSImporter(TestCase):
         content = {
             'item': u'Caça',
             'qtde': 1,
-            }
+        }
 
         self.assertEquals(self.importer.cleaned_data[0], (1, content),
                           self.importer.cleaned_data)
@@ -129,7 +152,7 @@ class TestPTBRXLSImporter(TestCase):
         content = {
             'item': u'Amanhã',
             'qtde': 2,
-            }
+        }
 
         self.assertEquals(self.importer.cleaned_data[1], (2, content),
                           self.importer.cleaned_data)
@@ -137,7 +160,7 @@ class TestPTBRXLSImporter(TestCase):
         content = {
             'item': u'Qüanto',
             'qtde': 3,
-            }
+        }
 
         self.assertEquals(self.importer.cleaned_data[2], (3, content),
                           self.importer.cleaned_data)
@@ -145,9 +168,7 @@ class TestPTBRXLSImporter(TestCase):
         content = {
             'item': u'Será',
             'qtde': 4,
-            }
+        }
 
         self.assertEquals(self.importer.cleaned_data[3], (4, content),
                           self.importer.cleaned_data)
-
-


### PR DESCRIPTION
…ionary. Examples:Importer lets you use the data with the 'self.fields' field as a dictionary. Examples:

# Examples 1
class TestMetaDict(XLSImporter):
	fields = {
	    'business_place': 'A',
	    'doc_number': 'b',
	    'doc_data': 'C',
	}

    class Meta:
        ignore_first_line = True

# Examples 2
class TestMetaDict(XLSImporter):
	fields = {
	    'business_place': 0,
	    'doc_number': 1,
	    'doc_data': 2,
	}

    class Meta:
        ignore_first_line = True

# Examples 3
 class TestMetaDict(XLSImporter):
	fields = {
	    'business_place': '0',
	    'doc_number': 1,
	    'doc_data': 'C',
	}

    class Meta:
        ignore_first_line = True