### PR TITLE
add importer for xls-html files

### DIFF
--- a/data_importer/__init__.py
+++ b/data_importer/__init__.py
@@ -3,5 +3,5 @@
 
 
 __doc__ = 'Data Importer'
-__version__ = '2.3.7'
+__version__ = '2.3.8'
 __author__ = 'Valder Gallo <valdergallo@gmail.com>'

--- a/data_importer/__init__.py
+++ b/data_importer/__init__.py
@@ -3,5 +3,5 @@
 
 
 __doc__ = 'Data Importer'
-__version__ = '2.3.6'
+__version__ = '2.3.7'
 __author__ = 'Valder Gallo <valdergallo@gmail.com>'

--- a/data_importer/__init__.py
+++ b/data_importer/__init__.py
@@ -3,5 +3,5 @@
 
 
 __doc__ = 'Data Importer'
-__version__ = '2.3.2'
+__version__ = '2.3.3'
 __author__ = 'Valder Gallo <valdergallo@gmail.com>'

--- a/data_importer/__init__.py
+++ b/data_importer/__init__.py
@@ -3,5 +3,5 @@
 
 
 __doc__ = 'Data Importer'
-__version__ = '2.3.8'
+__version__ = '2.3.6'
 __author__ = 'Valder Gallo <valdergallo@gmail.com>'

--- a/data_importer/importers/__init__.py
+++ b/data_importer/importers/__init__.py
@@ -3,4 +3,5 @@ from data_importer.importers.csv_importer import *
 from data_importer.importers.xls_importer import *
 from data_importer.importers.xlsx_importer import *
 from data_importer.importers.xml_importer import *
+from data_importer.importers.xls_html_importer import *
 from data_importer.importers.generic import *

--- a/data_importer/importers/base.py
+++ b/data_importer/importers/base.py
@@ -13,7 +13,7 @@ from data_importer.core.base import objclass2dict
 from data_importer.core.base import DATA_IMPORTER_EXCEL_DECODER
 from data_importer.core.base import DATA_IMPORTER_DECODER
 from collections import OrderedDict
-
+import traceback
 
 ALPHABETIC = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ'
 FACTOR = 26
@@ -190,17 +190,23 @@ class BaseImporter(object):
         """
         Read clean functions from importer and return tupla with row number, field and value
         """
-
+        l = len(values)
         if isinstance(self.fields, dict):
             values_encoded = []
             for key, value in self.fields.items():
                 try:
                     values_encoded.append(values[value])
                 except IndexError as e:
-                    index = self.original_fields.get(key)
-                    if isinstance(index, str):
-                        index = '"{}"'.format(index)
-                    raise IndexError(e.message + '. Index with error: [ "{0}" : {1} ]'.format(key, index))
+                    # index = self.original_fields.get(key)
+                    # if isinstance(index, str):
+                    #     index = '"{}"'.format(index)
+                    # raise IndexError(e.message + '. Index with error: [ "{0}" : {1} ]'.format(key, index))
+                    print u'values: {}'.format(values)
+                    print u'value: {}'.format(value)
+                    print u'key: {}'.format(key)
+                    print u'row: {}'.format(row)
+                    print u'l: {} - {}'.format(l, len(values))
+                    traceback.print_exc()
         else:
             values_encoded = [self.to_unicode(i) for i in values]
         try:

--- a/data_importer/importers/base.py
+++ b/data_importer/importers/base.py
@@ -197,16 +197,8 @@ class BaseImporter(object):
                 try:
                     values_encoded.append(values[value])
                 except IndexError as e:
-                    # index = self.original_fields.get(key)
-                    # if isinstance(index, str):
-                    #     index = '"{}"'.format(index)
-                    # raise IndexError(e.message + '. Index with error: [ "{0}" : {1} ]'.format(key, index))
-                    print u'values: {}'.format(values)
-                    print u'value: {}'.format(value)
-                    print u'key: {}'.format(key)
-                    print u'row: {}'.format(row)
-                    print u'l: {} - {}'.format(l, len(values))
-                    traceback.print_exc()
+                    self._error.append(self.get_error_message(e, row))
+                    return None
         else:
             values_encoded = [self.to_unicode(i) for i in values]
         try:

--- a/data_importer/importers/xls_html_importer.py
+++ b/data_importer/importers/xls_html_importer.py
@@ -1,0 +1,12 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+from data_importer.importers.base import BaseImporter
+from data_importer.readers import XLSHTMLReader
+
+
+class XLSHTMLImporter(BaseImporter):
+    table_selector = 'table'
+
+    def set_reader(self):
+        self._reader = XLSHTMLReader(self)

--- a/data_importer/readers/__init__.py
+++ b/data_importer/readers/__init__.py
@@ -2,3 +2,4 @@ from data_importer.readers.csv_reader import *
 from data_importer.readers.xls_reader import *
 from data_importer.readers.xlsx_reader import *
 from data_importer.readers.xml_reader import *
+from data_importer.readers.xls_html_reader import *

--- a/data_importer/readers/xls_html_reader.py
+++ b/data_importer/readers/xls_html_reader.py
@@ -13,7 +13,8 @@ class XLSHTMLReader(object):
         main_table = beautiful_soup.find(self.instance.table_selector)
         for tr in main_table.find_all('tr'):
             values = [self.clean_td(td.string) for td in tr.find_all('td')]
-            yield values
+            if values:
+                yield values
 
     @classmethod
     def clean_td(cls, string):

--- a/data_importer/readers/xls_html_reader.py
+++ b/data_importer/readers/xls_html_reader.py
@@ -1,0 +1,20 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+from bs4 import BeautifulSoup
+
+
+class XLSHTMLReader(object):
+    def __init__(self, instance):
+        self.instance = instance
+
+    def read(self):
+        html = open(u'{}'.format(self.instance.source), 'rb')
+        beautiful_soup = BeautifulSoup(html, 'html.parser')
+        main_table = beautiful_soup.find(self.instance.table_selector)
+        for tr in main_table.find_all('tr'):
+            values = [self.clean_td(td.string) for td in tr.find_all('td')]
+            yield values
+
+    @classmethod
+    def clean_td(cls, string):
+        return string.replace('\n', '')

--- a/setup.py
+++ b/setup.py
@@ -21,6 +21,7 @@ install_requires = [
     'django>=1.4',
     'openpyxl>=2.1.4',
     'xlrd>=0.9.3',
+    'beautifulsoup4==4.4.1',
 ]
 
 tests_require = [


### PR DESCRIPTION
This format are used by Microsoft Excel to export read only files, the file extension  is "XLS" but the content is HTML like this:
`<html>
<head>
    <meta http-equiv="Content-Type" content="text/html; charset=ISO-8859-1">
    <meta name="generator" content="SQL*Plus 11.2.0">
    <style type='text/css'> body {
        font: 10pt Arial, Helvetica, sans-serif;
        color: black;
        background: White;
    }

    p {
        font: 10pt Arial, Helvetica, sans-serif;
        color: black;
        background: White;
    }

    table, tr, td {
        font: 10pt Arial, Helvetica, sans-serif;
        color: Black;
        background: #f7f7e7;
        padding: 0px 0px 0px 0px;
        margin: 0px 0px 0px 0px;
    }

    th {
        font: bold 10pt Arial, Helvetica, sans-serif;
        color: #336699;
        background: #cccc99;
        padding: 0px 0px 0px 0px;
    }

    h1 {
        font: 16pt Arial, Helvetica, Geneva, sans-serif;
        color: #336699;
        background-color: White;
        border-bottom: 1px solid #cccc99;
        margin-top: 0pt;
        margin-bottom: 0pt;
        padding: 0px 0px 0px 0px;
        -}

    h2 {
        font: bold 10pt Arial, Helvetica, Geneva, sans-serif;
        color: #336699;
        background-color: White;
        margin-top: 4pt;
        margin-bottom: 0pt;
    }

    a {
        font: 9pt Arial, Helvetica, sans-serif;
        color: #663300;
        background: #ffffff;
        margin-top: 0pt;
        margin-bottom: 0pt;
        vertical-align: top;
    }</style>
    <title>SQL*Plus Report</title>
</head>
<body>
<p>
<table border='1' width='90%' align='center' summary='Script output'>
    <tr>
        <th scope="col">title1</th>
        <th scope="col">title2</th>
        <th scope="col">title3</th>
    </tr>
    <tr>
        <td> TAF</td>
        <td> 000000000047367</td>
        <td> NOKIA-SIEMENS</td>
    </tr>

</table>
<p>
</body>
</html>`