### PR TITLE
Fix "Prefer `format()` over string interpolation operator" issue

### DIFF
--- a/data_importer/importers/base.py
+++ b/data_importer/importers/base.py
@@ -174,10 +174,10 @@ class BaseImporter(object):
                 pass  # do nothing if not find this field in model
             except ValidationError as msg:
                 default_msg = msg.messages[0].replace('This field', '')
-                new_msg = 'Field (%s) %s' % (field.name, default_msg)
+                new_msg = 'Field ({0!s}) {1!s}'.format(field.name, default_msg)
                 raise ValidationError(new_msg)
 
-        clean_function = getattr(self, 'clean_%s' % field_name, False)
+        clean_function = getattr(self, 'clean_{0!s}'.format(field_name), False)
 
         if clean_function:
             return clean_function(value)
@@ -206,7 +206,7 @@ class BaseImporter(object):
             else:
                 values = dict(zip(self.fields, values_encoded))
         except TypeError:
-            raise TypeError('Invalid Line: %s' % row)
+            raise TypeError('Invalid Line: {0!s}'.format(row))
 
         has_error = False
 
@@ -243,10 +243,10 @@ class BaseImporter(object):
         messages = ''
 
         if not error_type:
-            error_type = "%s" % type(error).__name__
+            error_type = "{0!s}".format(type(error).__name__)
 
         if hasattr(error, 'message') and error.message:
-            messages = '%s' % error.message
+            messages = '{0!s}'.format(error.message)
 
         if hasattr(error, 'messages') and not messages:
             if error.messages:

--- a/data_importer/models.py
+++ b/data_importer/models.py
@@ -42,7 +42,7 @@ CELERY_STATUS = ((1, 'Imported'),
 
 def get_random_filename(instance, filename):
     _, ext = os.path.splitext(filename)
-    filename = "%s%s" % (str(uuid.uuid4()), ext)
+    filename = "{0!s}{1!s}".format(str(uuid.uuid4()), ext)
     user_dir = "anonymous"
     if instance.owner:
         user_dir = instance.owner.get_username()
@@ -70,7 +70,7 @@ class FileHistory(models.Model):
 
     def file_link(self):
         _url = self.file_upload.url
-        return "<a href='%s' tartget='_blank'>Download</a>" % _url
+        return "<a href='{0!s}' tartget='_blank'>Download</a>".format(_url)
 
     file_link.allow_tags = True
 
@@ -96,11 +96,11 @@ class FileHistory(models.Model):
         archive = zipfile.ZipFile(temp, 'w', zipfile.ZIP_DEFLATED)
         for index in range(10):
             filename = self.filename.path
-            archive.write(filename, 'file%d.txt' % index)
+            archive.write(filename, 'file{0:d}.txt'.format(index))
         archive.close()
         wrapper = FileWrapper(temp)
         response = HttpResponse(wrapper, content_type='application/zip')
-        response['Content-Disposition'] = 'attachment; filename=%s.zip' % self.filename
+        response['Content-Disposition'] = 'attachment; filename={0!s}.zip'.format(self.filename)
         response['Content-Length'] = temp.tell()
         temp.seek(0)
         return response
@@ -108,4 +108,4 @@ class FileHistory(models.Model):
     @property
     def compose_file_name(self):
         basename = os.path.basename(self.file_upload.file.name)
-        return "%s (%s)" % (basename, self.owner)
+        return "{0!s} ({1!s})".format(basename, self.owner)

--- a/data_importer/tasks.py
+++ b/data_importer/tasks.py
@@ -54,7 +54,7 @@ class DataImpoterTask(Task):
 
         self.parser = importer(source=source)
 
-        lock_id = "%s-lock" % (self.name)
+        lock_id = "{0!s}-lock".format((self.name))
 
         if acquire_lock(lock_id):
             """

--- a/data_importer/tests/test_models.py
+++ b/data_importer/tests/test_models.py
@@ -24,5 +24,5 @@ class TestDataImporterModels(TestCase):
         today = date.today().strftime("%Y/%m/%d")
         rand_filename = models.get_random_filename(instance, filename)
 
-        expected_name = 'upload_history/anonymous/%s/fake_uuid4.xls' % today
+        expected_name = 'upload_history/anonymous/{0!s}/fake_uuid4.xls'.format(today)
         self.assertEqual(rand_filename, expected_name)

--- a/data_importer/views.py
+++ b/data_importer/views.py
@@ -73,7 +73,7 @@ class DataImporterForm(FormView):
             if owner:
                 messages.info(
                     self.request,
-                    "When importer was finished one email will send to: %s" % owner.email
+                    "When importer was finished one email will send to: {0!s}".format(owner.email)
                 )
             else:
                 messages.info(

--- a/data_importer/writers/utils.py
+++ b/data_importer/writers/utils.py
@@ -58,7 +58,7 @@ class QuerysetToWorkbook(object):
         letters = re.findall('[A-Z]', dimensions)
         first = letters.pop(0)
         second = ''.join(letters)
-        return '%s1:%s1' % (first, second)
+        return '{0!s}1:{1!s}1'.format(first, second)
 
     def set_header_style(self, row=1):
         try:
@@ -139,6 +139,6 @@ class QuerysetToWorkbook(object):
         if not filename:
             filename = _filename
 
-        response['Content-Disposition'] = 'attachment; filename=%s' % filename
+        response['Content-Disposition'] = 'attachment; filename={0!s}'.format(filename)
         response['content_type'] = 'application/force-download'
         return response

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -307,14 +307,14 @@ def process_docstring(app, what, name, obj, options, lines):
             if help_text:
                 # Add the model field to the end of the docstring as a param
                 # using the help text as the description
-                lines.append(u':param %s: %s' % (field.attname, help_text))
+                lines.append(u':param {0!s}: {1!s}'.format(field.attname, help_text))
             else:
                 # Add the model field to the end of the docstring as a param
                 # using the verbose name as the description
-                lines.append(u':param %s: %s' % (field.attname, verbose_name))
+                lines.append(u':param {0!s}: {1!s}'.format(field.attname, verbose_name))
 
             # Add the field's type to the docstring
-            lines.append(u':type %s: %s' % (field.attname, type(field).__name__))
+            lines.append(u':type {0!s}: {1!s}'.format(field.attname, type(field).__name__))
 
     # Return the extended docstring
     return lines

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ tests_require = [
 setup(
     name='data-importer',
     url='https://github.com/valdergallo/data-importer',
-    download_url='https://github.com/valdergallo/data-importer/tarball/%s/' % data_importer.__version__,
+    download_url='https://github.com/valdergallo/data-importer/tarball/{0!s}/'.format(data_importer.__version__),
     author="valdergallo",
     author_email='valdergallo@gmail.com',
     keywords='Django Data Importer XLS XLSX CSV XML',


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Prefer `format()` over string interpolation operator](https://www.quantifiedcode.com/app/issue_class/4ACGxFj1)
Issue details: [https://www.quantifiedcode.com/app/project/gh:valdergallo:data-importer?groups=code_patterns/%3A4ACGxFj1](https://www.quantifiedcode.com/app/project/gh:valdergallo:data-importer?groups=code_patterns/%3A4ACGxFj1)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)