### PR TITLE
Fix for Python 3.0 / Django 2.2-3.0

### DIFF
--- a/data_importer/importers/base.py
+++ b/data_importer/importers/base.py
@@ -126,7 +126,7 @@ class BaseImporter(object):
         if hasattr(self, 'fields') and isinstance(self.fields, dict):
             order_dict = OrderedDict(self.fields)
             self.fields = list(self.fields)
-            self._reduce_list = map(convert_alphabet_to_number, order_dict.values())
+            self._reduce_list = list(map(convert_alphabet_to_number, order_dict.values()))
 
         if self.Meta.exclude and not self._excluded:
             self._excluded = True


### PR DESCRIPTION
Map works differently under python 3 and the reduce list construction failed starting from Django 2.2 up and including to Django 3.0. Without this fix, the reduce_list is empty as if there was no content in the file.