### PR TITLE
Fix import issue for Django 3.1.2

### DIFF
--- a/data_importer/importers/base.py
+++ b/data_importer/importers/base.py
@@ -7,7 +7,7 @@ import io
 import six
 import codecs
 from django.db import transaction
-from django.db.models.fields import FieldDoesNotExist
+from django.core.exceptions import FieldDoesNotExist
 from django.core.exceptions import ValidationError
 from data_importer.core.descriptor import ReadDescriptor
 from data_importer.core.exceptions import StopImporter


### PR DESCRIPTION
The import path for FieldDoesNotExist has changed in recent version of django. See https://stackoverflow.com/questions/63300404/makemigration-error-on-django-importerror-cannot-import-name-fielddoesnotexi