### PR TITLE
Replace deprecated `force_text` with `force_str`

### DIFF
--- a/data_importer/importers/base.py
+++ b/data_importer/importers/base.py
@@ -18,7 +18,7 @@ from data_importer.core.base import convert_alphabet_to_number
 from data_importer.core.base import reduce_list
 from collections import OrderedDict
 try:
-    from django.utils.encoding import force_text
+    from django.utils.encoding import force_str
 except ImportError:
     from django.utils.encoding import force_unicode as force_text
 


### PR DESCRIPTION
`force_text` was obsolete in Django 3.0 and now deprecated in Django 4.0. Replace with `smart_str`.

https://docs.djangoproject.com/en/4.0/releases/3.0/#deprecated-features-3-0